### PR TITLE
samsung32 fixes

### DIFF
--- a/lib/ir/ir_protocol_registry.dart
+++ b/lib/ir/ir_protocol_registry.dart
@@ -112,6 +112,7 @@ class IrProtocolRegistry {
     Recs80ProtocolEncoder.protocolId: const Recs80ProtocolEncoder(),
     Recs80LProtocolEncoder.protocolId: const Recs80LProtocolEncoder(),
 
+    Samsung32ProtocolEncoder.protocolId: const Samsung32ProtocolEncoder(),
     Samsung36ProtocolEncoder.protocolId: const Samsung36ProtocolEncoder(),
     SharpProtocolEncoder.protocolId: const SharpProtocolEncoder(),
 

--- a/lib/widgets/ir_finder_screen.dart
+++ b/lib/widgets/ir_finder_screen.dart
@@ -312,7 +312,7 @@ class _IrFinderScreenState extends State<IrFinderScreen> with WidgetsBindingObse
     'rec80': '28C600212100',
     'recs80': '000',
     'recs80_l': '000',
-    'samsung32': '00000000',
+    'samsung32': '0000',
     'samsung36': '00C0001',
     'sharp': '2024',
     'sony12': '000',


### PR DESCRIPTION
- Allow usage of samsung32 encoder
- Set correct payload size for bruteforcing