### PR TITLE
deactivate usb transmitter if not being used

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -48,7 +48,7 @@ android {
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
-        resConfigs "en"
+        resourceConfigurations += ['en']
     }
 
     signingConfigs {
@@ -82,10 +82,10 @@ android {
             }
         }
     }
-
-    lintOptions {
+    lint {
         checkReleaseBuilds false
     }
+
 }
 
 flutter {

--- a/android/app/src/main/kotlin/org/nslabs/irblaster/MainActivity.kt
+++ b/android/app/src/main/kotlin/org/nslabs/irblaster/MainActivity.kt
@@ -478,6 +478,26 @@ class MainActivity : FlutterActivity() {
         emitTxStatusDelayed("startup_done_delayed", 350L)
     }
 
+    override fun onPause() {
+        super.onPause()
+        // Aggressively save power: close the USB connection when the app goes to background.
+        // It will be re-opened automatically via acquireUsbTransmitter() when needed for transmission.
+        usbTransmitter?.closeSafely()
+        usbTransmitter = null
+        refreshUsbStateSnapshot()
+        emitTxStatus("app_paused")
+    }
+
+    override fun onResume() {
+        super.onResume()
+        // Re-open if it was previously active or if auto-switch is enabled.
+        if (currentTxType == TxType.USB) {
+            openUsbIfPermitted()?.let { usbTransmitter = it }
+        }
+        applyAutoSwitchIfEnabled("app_resume")
+        emitTxStatus("app_resume")
+    }
+
     private fun handlePerformHaptic(call: MethodCall, result: MethodChannel.Result) {
         val type = call.argument<String>("type") ?: "selection"
         val intensity = (call.argument<Int>("intensity") ?: 2).coerceIn(1, 3)

--- a/android/app/src/main/kotlin/org/nslabs/irblaster/usb/UsbIrTransmitter.kt
+++ b/android/app/src/main/kotlin/org/nslabs/irblaster/usb/UsbIrTransmitter.kt
@@ -1,5 +1,6 @@
 package org.nslabs.ir_blaster
 
+import android.annotation.SuppressLint
 import android.hardware.usb.UsbDevice
 import android.hardware.usb.UsbDeviceConnection
 import android.hardware.usb.UsbEndpoint
@@ -14,6 +15,7 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import java.util.concurrent.atomic.AtomicLong
 
+@SuppressLint("NewApi")
 class UsbIrTransmitter private constructor(
     val device: UsbDevice,
     private val connection: UsbDeviceConnection,
@@ -142,12 +144,22 @@ class UsbIrTransmitter private constructor(
                 val until = readUntilMs.get()
                 val now = System.currentTimeMillis()
                 if (until <= now) break
+                
                 try {
-                    connection.bulkTransfer(inEndpoint, buf, buf.size, 300)
-                    delay(1)
+                    val remainingMs = (until - now).toInt()
+                    val timeout = remainingMs.coerceIn(50, 200)
+                    val rc = connection.bulkTransfer(inEndpoint, buf, buf.size, timeout)
+                    
+                    if (rc > 0) {
+                        delay(10)
+                    } else {
+                        delay(100)
+                    }
                 } catch (t: Throwable) {
-                    Log.e(TAG, "Background reader error", t)
-                    delay(5)
+                    if (isActive && !closed) {
+                        Log.e(TAG, "Background reader error", t)
+                        delay(1000)
+                    }
                 }
             }
         }


### PR DESCRIPTION
when inserted the USB transmitter into the Android device it drains the battery very much. Deactivate the transmitter as soon as possible to save power. 